### PR TITLE
Fix path.exists output

### DIFF
--- a/library/pl/path.lua
+++ b/library/pl/path.lua
@@ -60,7 +60,7 @@ function path.getsize(P) end
 
 ---does a path exist?
 ---@param P string -- A file path
----@return boolean
+---@return string|false
 ---@nodiscard
 function path.exists(P) end
 


### PR DESCRIPTION
as of penlight 1.14.0, `path.exists(P)` return `P` if it exists, `false` otherwise. In particular, `path.exists(P)==true` is always false.
